### PR TITLE
Allow Grid layout to be able to use by column count or column width.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ All these will yield vertical linear or grid layouts.
 
 ```rrvEmptyLayoutId```: A custom empty state view can be provided via this attribute. Whenever the list has no item, the empty state is shown. 
 
-```rrvGridLayoutSpanCount```: This attribute has to be set with an integer greater than zero when the ```rrvLayoutType``` is set to ```Grid```. 
+```rrvGridLayoutSpanCount```: This attribute has to be set with an integer greater than zero when the ```rrvLayoutType``` is set to ```Grid``` unless ```rrvGridLayoutItemWidth``` is set.
+
+ ```rrvGridLayoutItemWidth```: This attribute has to be set with a size value that represents the width of a grid column when the ```rrvLayoutType``` is set to ```Grid``` unless ```rrvGridLayoutSpanCount``` is set.
 
 ```rrvSwipeToDelete```: This attribute is only supported with ```rrvLayoutType``` of ```LinearLayout```. If set to true, swiping a row to delete is enabled. The row is deleted from the ```Realm``` directly.
 

--- a/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
@@ -57,6 +57,8 @@ public class RealmRecyclerView extends FrameLayout {
     private GridLayoutManager gridManager;
     private boolean swipeToDelete;
 
+    private int lastMeasuredWidth = -1;
+
     // State
     private boolean isRefreshing;
 
@@ -82,9 +84,10 @@ public class RealmRecyclerView extends FrameLayout {
     @Override
     protected void onMeasure(int widthSpec, int heightSpec) {
         super.onMeasure(widthSpec, heightSpec);
-        if (gridWidth != -1 && gridManager != null) {
+        if (gridWidth != -1 && gridManager != null && lastMeasuredWidth != getMeasuredWidth()) {
             int spanCount = Math.max(1, getMeasuredWidth() / gridWidth);
             gridManager.setSpanCount(spanCount);
+            lastMeasuredWidth = getMeasuredWidth();
         }
     }
 

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -9,7 +9,7 @@
             <enum name="LinearLayoutWithHeaders" value="2"/>
         </attr>
         <attr name="rrvGridLayoutSpanCount" format="integer"/>
-        <attr name="rrvGridLayoutItemWidth" format="integer"/>
+        <attr name="rrvGridLayoutItemWidth" format="dimension"/>
         <attr name="rrvHeaderColumnName" format="string"/>
         <attr name="rrvSwipeToDelete" format="boolean"/>
     </declare-styleable>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
             <enum name="LinearLayoutWithHeaders" value="2"/>
         </attr>
         <attr name="rrvGridLayoutSpanCount" format="integer"/>
+        <attr name="rrvGridLayoutItemWidth" format="integer"/>
         <attr name="rrvHeaderColumnName" format="string"/>
         <attr name="rrvSwipeToDelete" format="boolean"/>
     </declare-styleable>


### PR DESCRIPTION
There are times when, to make use of Android's many screen sizes it supports, it makes more sense to fill the available space with fixed size items of variable amounts than stretch/squeeze items with fixed columns. Setting an item width allows the columns to dynamically change count based on space available.

FYI: have not been able to test this due to https://github.com/thorbenprimke/realm-recyclerview/issues/5.
