### PR TITLE
Allow headers to come from other row types than strings.

### DIFF
--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -363,14 +363,12 @@ public abstract class RealmBasedRecyclerViewAdapter
         String result = null;
         if (columnValue instanceof Boolean) {
             result = columnValue.toString();
-        }
-
-        if (columnValue instanceof String) {
+        } else if (columnValue instanceof String) {
             result = ((String) columnValue).substring(0, 1);
-        }
-
-        if (columnValue instanceof Long) {
+        } else if (columnValue instanceof Long) {
             result = columnValue.toString();
+        } else {
+            throw new IllegalStateException("columnType not supported");
         }
 
         return result;
@@ -443,7 +441,7 @@ public abstract class RealmBasedRecyclerViewAdapter
             final long headerIndex = realmResults.getTable().getColumnIndex(headerColumnName);
             int i = 0;
             for (RealmModel result : realmResults) {
-                Object rawHeader = null;
+                Object rawHeader;
                 RealmFieldType fieldType = ((RealmObjectProxy) result)
                         .realmGet$proxyState().getRow$realm().getColumnType(headerIndex);
 
@@ -451,16 +449,14 @@ public abstract class RealmBasedRecyclerViewAdapter
                     rawHeader = ((RealmObjectProxy) result)
                             .realmGet$proxyState().getRow$realm().getString(headerIndex);
 
-                }
-
-                if (fieldType == RealmFieldType.BOOLEAN) {
+                } else if (fieldType == RealmFieldType.BOOLEAN) {
                     rawHeader = ((RealmObjectProxy) result)
                             .realmGet$proxyState().getRow$realm().getBoolean(headerIndex);
-                }
-
-                if (fieldType == RealmFieldType.INTEGER) {
+                } else if (fieldType == RealmFieldType.INTEGER) {
                     rawHeader = ((RealmObjectProxy) result)
                             .realmGet$proxyState().getRow$realm().getLong(headerIndex);
+                } else {
+                    throw new IllegalStateException("columnValue type not supported");
                 }
 
                 String header = createHeaderFromColumnValue(rawHeader);

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -359,8 +359,22 @@ public abstract class RealmBasedRecyclerViewAdapter
      * Method that creates the header string that should be used. Override this method to have
      * a custom header.
      */
-    public String createHeaderFromColumnValue(String columnValue) {
-        return columnValue.substring(0, 1);
+    public String createHeaderFromColumnValue(Object columnValue) {
+        String result = null;
+        if (columnValue instanceof Boolean) {
+            result = columnValue.toString();
+        }
+
+        if (columnValue instanceof String) {
+            result = ((String) columnValue).substring(0, 1);
+        }
+
+        if (columnValue instanceof Long) {
+            result = columnValue.toString();
+        }
+
+        return result;
+
     }
 
     private List getIdsOfRealmResults() {
@@ -429,8 +443,26 @@ public abstract class RealmBasedRecyclerViewAdapter
             final long headerIndex = realmResults.getTable().getColumnIndex(headerColumnName);
             int i = 0;
             for (RealmModel result : realmResults) {
-                String rawHeader = ((RealmObjectProxy) result)
-                        .realmGet$proxyState().getRow$realm().getString(headerIndex);
+                Object rawHeader = null;
+                RealmFieldType fieldType = ((RealmObjectProxy) result)
+                        .realmGet$proxyState().getRow$realm().getColumnType(headerIndex);
+
+                if (fieldType == RealmFieldType.STRING) {
+                    rawHeader = ((RealmObjectProxy) result)
+                            .realmGet$proxyState().getRow$realm().getString(headerIndex);
+
+                }
+
+                if (fieldType == RealmFieldType.BOOLEAN) {
+                    rawHeader = ((RealmObjectProxy) result)
+                            .realmGet$proxyState().getRow$realm().getBoolean(headerIndex);
+                }
+
+                if (fieldType == RealmFieldType.INTEGER) {
+                    rawHeader = ((RealmObjectProxy) result)
+                            .realmGet$proxyState().getRow$realm().getLong(headerIndex);
+                }
+
                 String header = createHeaderFromColumnValue(rawHeader);
                 if (!TextUtils.equals(lastHeader, header)) {
                     // Insert new header view and update section data.

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -82,6 +82,7 @@ public abstract class RealmBasedRecyclerViewAdapter
     private final int LOAD_MORE_VIEW_TYPE = 101;
     private final int FOOTER_VIEW_TYPE = 102;
 
+    private Context context;
     protected LayoutInflater inflater;
     protected RealmResults<T> realmResults;
     protected List ids;
@@ -151,6 +152,7 @@ public abstract class RealmBasedRecyclerViewAdapter
             throw new IllegalArgumentException("Context cannot be null");
         }
 
+        this.context = context;
         this.animateResults = animateResults;
         this.addSectionHeaders = addSectionHeaders;
         this.headerColumnName = headerColumnName;
@@ -228,6 +230,10 @@ public abstract class RealmBasedRecyclerViewAdapter
         } else {
             layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT;
         }
+    }
+
+    public Context getContext() {
+        return context;
     }
 
     /**


### PR DESCRIPTION
The realm model could be sectioned using other row types than strings. My use case includes sectioning based on boolean values.
