### PR TITLE
Added support for horizontal orientation when using LayoutLinear

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ Important to note here is that the ```app:rrvLayoutType``` attribute has to be s
 
 All these will yield vertical linear or grid layouts.
 
+The snippet below shows how to include the create a horizontally oriented version of the above recycler view.
+
+```
+    <co.moonmonkeylabs.realmrecyclerview.RealmRecyclerView
+        android:id="@+id/realm_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:rrvIsRefreshable="true"
+        app:rrvEmptyLayoutId="@layout/empty_view"
+        app:rrvLayoutType="LinearLayout"
+        app:rrvOrientation="Horizontal"
+        />
+```
+
+The ```app:rrvOrientation``` can be ommited and it defaults to ```Vertical```.
+
 ###Other Attributes:
 
 ```rrvIsRefreshable```: Adds the pull-to-refresh feature to the ```recyclerView```. In order to receive the refresh events, a listner has to be set via ```setOnRefreshListener``` and ```setRefreshing``` is used to control either turn the refersh animation on/off.
@@ -65,6 +81,8 @@ All these will yield vertical linear or grid layouts.
  ```rrvGridLayoutItemWidth```: This attribute has to be set with a size value that represents the width of a grid column when the ```rrvLayoutType``` is set to ```Grid``` unless ```rrvGridLayoutSpanCount``` is set.
 
 ```rrvSwipeToDelete```: This attribute is only supported with ```rrvLayoutType``` of ```LinearLayout```. If set to true, swiping a row to delete is enabled. The row is deleted from the ```Realm``` directly.
+
+```rrvOrientation```: This attribute is currenty only supported with ```rrvLayoutType``` of ```LinearLayout```. It sets the orientation of the recycler's view ```LayoutManager``` allowing for layouts with horizontal orientation.
 
 ##RealmBasedRecyclerViewAdapter: 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A powerful ```Recyclerview``` wrapper for working with ```Realm``` as your datas
 * Pull-to-refresh (backed by SwipeRefreshLayout)
 * Infinite scrolling (callback for more data fetching)
 * Section headers (backed by SuperSLiM)
-
+* Optional horizontal orientation (currently only for linear layouts)
+                                                                                 
 ##How To Include It:
 
 ```
@@ -19,7 +20,7 @@ A powerful ```Recyclerview``` wrapper for working with ```Realm``` as your datas
 
 ```
 	dependencies {
-	        compile 'com.github.thorbenprimke:realm-recyclerview:0.9.20'
+	        compile 'com.github.loudenvier:realm-recyclerview:0.9.22'
 	}
 ```
 
@@ -54,7 +55,7 @@ Important to note here is that the ```app:rrvLayoutType``` attribute has to be s
 
 All these will yield vertical linear or grid layouts.
 
-The snippet below shows how to include the create a horizontally oriented version of the above recycler view.
+The snippet below shows how to create a horizontally oriented version of the above recycler view.
 
 ```
     <co.moonmonkeylabs.realmrecyclerview.RealmRecyclerView

--- a/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
@@ -278,13 +278,11 @@ public class RealmRecyclerView extends FrameLayout {
                 .getDimensionPixelSize(R.styleable.RealmRecyclerView_rrvGridLayoutItemWidth, -1);
         swipeToDelete =
                 typedArray.getBoolean(R.styleable.RealmRecyclerView_rrvSwipeToDelete, false);
-        typedArray.recycle();
-
         int orientationValue = typedArray.getInt(R.styleable.RealmRecyclerView_rrvOrientation, -1);
         if (orientationValue != -1) {
             orientation = Orientation.values()[typeValue];
         }
-
+        typedArray.recycle();
     }
 
     public void addItemDecoration(RecyclerView.ItemDecoration decor) {

--- a/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
@@ -36,6 +36,10 @@ public class RealmRecyclerView extends FrameLayout {
         Grid,
         LinearLayoutWithHeaders
     }
+    private enum Orientation {
+        Vertical,
+        Horizontal
+    }
 
     private SwipeRefreshLayout swipeRefreshLayout;
     private RecyclerView recyclerView;
@@ -53,6 +57,12 @@ public class RealmRecyclerView extends FrameLayout {
     private int gridWidthPx;
     private boolean swipeToDelete;
     private int bufferItems = 3;
+    private Orientation orientation;
+    private int getOrientationValue() {
+        return orientation == Orientation.Horizontal
+                ? LinearLayoutManager.HORIZONTAL
+                : LinearLayoutManager.VERTICAL;
+    }
 
     private GridLayoutManager gridManager;
     private int lastMeasuredWidth = -1;
@@ -119,7 +129,8 @@ public class RealmRecyclerView extends FrameLayout {
         }
         switch (type) {
             case LinearLayout:
-                recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+                recyclerView.setLayoutManager(new LinearLayoutManager(getContext(),
+                        getOrientationValue(), false));
                 break;
 
             case Grid:
@@ -179,12 +190,6 @@ public class RealmRecyclerView extends FrameLayout {
         }
     }
 
-    /**
-     * Sets the orientation of the layout. {@link android.support.v7.widget.LinearLayoutManager}
-     * will do its best to keep scroll position.
-     *
-     * @param orientation {@link #HORIZONTAL} or {@link #VERTICAL}
-     */
     public void setOrientation(int orientation) {
         if(gridManager == null) {
             throw new IllegalStateException("Error init of GridLayoutManager");
@@ -274,6 +279,12 @@ public class RealmRecyclerView extends FrameLayout {
         swipeToDelete =
                 typedArray.getBoolean(R.styleable.RealmRecyclerView_rrvSwipeToDelete, false);
         typedArray.recycle();
+
+        int orientationValue = typedArray.getInt(R.styleable.RealmRecyclerView_rrvOrientation, -1);
+        if (orientationValue != -1) {
+            orientation = Orientation.values()[typeValue];
+        }
+
     }
 
     public void addItemDecoration(RecyclerView.ItemDecoration decor) {

--- a/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
@@ -285,7 +285,7 @@ public class RealmRecyclerView extends FrameLayout {
                 typedArray.getBoolean(R.styleable.RealmRecyclerView_rrvSwipeToDelete, false);
         int orientationValue = typedArray.getInt(R.styleable.RealmRecyclerView_rrvOrientation, -1);
         if (orientationValue != -1) {
-            orientation = Orientation.values()[typeValue];
+            orientation = Orientation.values()[orientationValue];
         }
         typedArray.recycle();
     }

--- a/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
+++ b/library/src/main/java/co/moonmonkeylabs/realmrecyclerview/RealmRecyclerView.java
@@ -107,8 +107,13 @@ public class RealmRecyclerView extends FrameLayout {
     }
 
     private void init(Context context, AttributeSet attrs) {
-        inflate(context, R.layout.realm_recycler_view, this);
         initAttrs(context, attrs);
+        // the layout was hardcoded for vertical orientation: easy way out? create a duplicate but horizontal
+        if (orientation == Orientation.Horizontal) {
+            inflate(context, R.layout.realm_recycler_view_horizontal, this);
+        } else {
+            inflate(context, R.layout.realm_recycler_view, this);
+        }
 
         swipeRefreshLayout = (SwipeRefreshLayout) findViewById(R.id.rrv_swipe_refresh_layout);
         recyclerView = (RecyclerView) findViewById(R.id.rrv_recycler_view);

--- a/library/src/main/res/layout/realm_recycler_view_horizontal.xml
+++ b/library/src/main/res/layout/realm_recycler_view_horizontal.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/rrv_swipe_refresh_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/rrv_recycler_view"
+            android:scrollbars="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+    </android.support.v4.widget.SwipeRefreshLayout>
+
+    <ViewStub
+        android:id="@+id/rrv_empty_content_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"/>
+</FrameLayout>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -8,6 +8,10 @@
             <enum name="Grid" value="1"/>
             <enum name="LinearLayoutWithHeaders" value="2"/>
         </attr>
+        <attr name="rrvOrientation">
+            <enum name="Vertical" value="0"/>
+            <enum name="Horizontal" value="1"/>
+        </attr>
         <attr name="rrvGridLayoutSpanCount" format="integer"/>
         <attr name="rrvGridLayoutItemWidth" format="dimension"/>
         <attr name="rrvHeaderColumnName" format="string"/>


### PR DESCRIPTION
I've just done the most basic changes to allow horizontal orientation when using LayoutLinear. I didn't tried to be "smart" so I've written the changes as to cause less friction possible with the current codebase. There is probably a smarter way to implement that than what I did (for example, I've duplicated and adapted the realm_recycler_view.xml into realm_recycler_view_horizontal.xml instead of keeping a single layout and configure it dynamically).

I didn't also test the changes with the swipe to refresh, and load more features. They may very well stop working if you set the orientation to horizontal. 

I didn't use an attribute for orientation which is tied to a layout (rrvLayoutLinearOrientation), instead opting for rrbOrientation since it could be used for other layouts (making the setOrientation method superfluous, for example).

I'm pretty much sure the code could be improved, but I think it is a good start point, so I'm creating this pull request.
