### PR TITLE
Fix issue when RealmResults is sorted on the same column as animateExtraColumnName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A RecyclerView that is powered by Realm
 
-A powerful ```Recyclerview``` wrapper for working with ```Realm``` as your datastore. It supports the following features out of the box:
+A powerful ```RecyclerView``` wrapper for working with ```Realm``` as your datastore. It supports the following features out of the box:
 
 * Custom adapter that automatically refreshes the list when the realm changes and animates the new items in.
 * Empty state
@@ -70,13 +70,15 @@ All these will yield vertical linear or grid layouts.
 
 ##RealmBasedRecyclerViewAdapter: 
 
-The heart of the ```RealmRecyclerView```'s functionality comes from this custom ```RecyclerView.Adapter```. It includes support for insertion/deletion animation whenever the ```Realm``` changes. It also inculde the logic to generate the headers for the list's contents if it's of type ```LinearLayoutWithHeaders```. 
+The heart of the ```RealmRecyclerView```'s functionality comes from this custom ```RecyclerView.Adapter```. It includes support for insertion/deletion animation and refreshing a row whenever the ```Realm``` changes. It also inculde the logic to generate the headers for the list's contents if it's of type ```LinearLayoutWithHeaders```. 
 
-* ```automaticUpdate```: If automaticUpdate is set, the ```RealmResults``` are automatially updated and the list is refershed with new results.
+* ```automaticUpdate```: If automaticUpdate is set, the ```RealmResults``` are automatically updated and the list is refreshed with new results.
 
-* ```animateResults```: If animateResults is set together with automaticUpdate, the automatic updates are animated. This is limited to a single deletion or insertion. If it's more than one item, it will simply refresh the list. The animation leverages the resuls primary key column in order as a unique identifier for each row. Therefore your ```Realm```'s schema needs to include a primary key column of type ```Integer``` or ```String```.
+* ```animateResults```: If animateResults is set together with automaticUpdate, the automatic updates are animated. This is limited to a single deletion or insertion. If it's more than one item, it will simply refresh the list. The animation leverages the results primary key column as a unique identifier for each row. Therefore your ```Realm```'s schema needs to include a primary key column of type ```Integer``` or ```String```.
 
-* ```addSectionHeaders```: When the ```rrvLayoutType``` is ```LinearLayoutWithHeaders```, addSectionHeaders needs be set in order for the adapter to generate the headers. The ```headerColumnName``` needs to be set as well in order to look up the header column programmatically your ```Realm```'s schema. *Note: There is currently no support for customizing the header and it is always inline|sticky.*
+* ```addSectionHeaders```: When the ```rrvLayoutType``` is ```LinearLayoutWithHeaders```, addSectionHeaders needs be set in order for the adapter to generate the headers. The ```headerColumnName``` needs to be set as well in order to look up the header column programmatically in your ```Realm```'s schema. *Note: There is currently no support for customizing the header and it is always inline|sticky.*
+
+* ```animateExtraColumnName```: When ```automaticUpdate``` and ```animateResults``` is set the primary key is used to detect changes. If the primary key does not change then **only** deletions and insertions will be updated in the list. Set animateExtraColumnName to be name of a column in your ```Realm```'s schema. The column must be of type ```Integer```, ```Date``` or ```String```. When a change to this column is detected then the matching row in the list will be refreshed. A timestamp that is incremented after any column is updated would work well as an animateExtraColumnName.
 
 ##Feedback/More Features:
 I would love to hear your feedback. Do you find the ```RealmRecyclerView``` useful? What functionality are you missing? Open a ```Github``` issue and let me know. Thanks!

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -355,7 +355,9 @@ public abstract class RealmBasedRecyclerViewAdapter
         updateRowWrappers();
         ids = getIdsOfRealmResults();
 
-        notifyDataSetChanged();
+        if (realmResults != null) {
+            notifyDataSetChanged();
+        }
     }
 
     /**

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -29,6 +29,8 @@ import com.tonicartos.superslim.GridSLM;
 import com.tonicartos.superslim.LinearSLM;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import co.moonmonkeylabs.realmrecyclerview.LoadMoreListItemView;
@@ -536,7 +538,19 @@ public abstract class RealmBasedRecyclerViewAdapter
                             notifyDataSetChanged();
                         }
                     } else {
-                        for (Delta delta : deltas) {
+                        ArrayList<Delta> sortedDeltas = new ArrayList<>(deltas);
+                        Collections.sort(sortedDeltas, new Comparator<Delta>() {
+                            @Override
+                            public int compare(Delta delta, Delta t1) {
+                                if (delta.getType() == t1.getType()) {
+                                    return 0;
+                                } else if (delta.getType() == Delta.TYPE.DELETE && t1.getType() == Delta.TYPE.INSERT) {
+                                    return -1;
+                                } else return 1;
+                            }
+                        });
+
+                        for (Delta delta : sortedDeltas) {
                             if (delta.getType() == Delta.TYPE.INSERT) {
                                 notifyItemRangeInserted(
                                         delta.getRevised().getPosition(),

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -183,14 +183,14 @@ public abstract class RealmBasedRecyclerViewAdapter
                         .getColumnIndex(animateExtraColumnName);
                 if (animateExtraColumnIndex == TableOrView.NO_MATCH) {
                     throw new IllegalStateException(
-                            "Animating the results requires a valid animateColumnName.");
+                            "Animating the results requires a valid animateExtraColumnName.");
                 }
                 animateExtraIdType = realmResults.getTable().getColumnType(animateExtraColumnIndex);
                 if (animateExtraIdType != RealmFieldType.INTEGER &&
                         animateExtraIdType != RealmFieldType.STRING &&
                         animateExtraIdType != RealmFieldType.DATE) {
                     throw new IllegalStateException(
-                            "Animating requires a animateColumnName of type Int/Long or String");
+                            "Animating requires a animateExtraColumnName of type Integer/Long, Date or String");
                 }
             } else {
                 animateExtraColumnIndex = -1;


### PR DESCRIPTION
Using animateExtraColumnName and having the RealmResults is sorted by the same column as animateExtraColumnName, there is the potential for a single row to have a change in animateExtraColumnName that will also change its row position.

If this occurs then the diff delta will be a INSERT and DELETE for that row.
If the insert is done first then the delete will be on the incorrect row. The result being that the original row will still be visible unchanged, the updated row will have then replaced an unrelated row at the new position. 

Example of what can occur.

| index | primarykey | animateExtraColumn |
| --- | --- | --- |
| 0 | abc | 100 |
| 1 | xyz | 75 |
| 2 | 123 | 50 |
| 3 | ijk | 20 |

**Before (RealmResults sorted DESC on animateExtraColumn)**
<br />

| index | primarykey | animateExtraColumn |
| --- | --- | --- |
| 0 | abc | 100 |
| 1 | 123 | 90 |
| 2 | 123 | 50 |
| 3 | ijk | 20 |

**After (primary key row 123 has had its animate column incremented to 90)**

This pull request re-sorts the delta's to ensure the DELETE takes place before the INSERT.

Documentation is also updated for the use of animateExtraColumnName.
