### PR TITLE
Allow getting the header at specified position, and expose RowWrappers

### DIFF
--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -376,6 +376,19 @@ public abstract class RealmBasedRecyclerViewAdapter
 
     }
 
+    public String getHeaderAtPosition(int position) {
+        for (int i = rowWrappers.size() - 1; i >= 0; i--) {
+            RowWrapper rowWrapper = rowWrappers.get(i);
+            if (!rowWrapper.isRealm) {
+                if (rowWrapper.sectionHeaderIndex <= position) {
+                    return rowWrapper.header;
+                }
+            }
+        }
+
+        return null;
+    }
+
     private List getIdsOfRealmResults() {
         if (!animateResults || realmResults == null || realmResults.size() == 0) {
             return EMPTY_LIST;

--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -489,6 +489,10 @@ public abstract class RealmBasedRecyclerViewAdapter
         }
     }
 
+    public List<RowWrapper> getRowWrappers() {
+        return rowWrappers;
+    }
+
     private RealmChangeListener<RealmResults<T>> getRealmChangeListener() {
         return new RealmChangeListener<RealmResults<T>>() {
             @Override


### PR DESCRIPTION
Allow specifying a position in order to get the header String for that position, and expose RowWrapper metadata so that it can be used for things like populating Fast Scroller lists.
