### PR TITLE
Add summary header to top of recycler view

### DIFF
--- a/library/src/main/res/layout/realm_recycler_view.xml
+++ b/library/src/main/res/layout/realm_recycler_view.xml
@@ -4,6 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ViewStub
+        android:id="@+id/rrv_empty_content_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/rrv_swipe_refresh_layout"
         android:layout_width="match_parent"
@@ -16,9 +22,4 @@
             android:layout_height="match_parent"/>
     </android.support.v4.widget.SwipeRefreshLayout>
 
-    <ViewStub
-        android:id="@+id/rrv_empty_content_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"/>
 </FrameLayout>


### PR DESCRIPTION
Added summary header

Separated formatting of section headers from retrieving value from realm - allows for heavy formatting operations such as date formatting to be done only when required rather than on every item